### PR TITLE
Redo Slider interface

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,6 @@
 .DS_Store
 coverage
 package/**/coverage
-packages/**/dist
+packages/**/dist/*
 packages/example/build
 packages/**/node_modules

--- a/packages/example/src/App.js
+++ b/packages/example/src/App.js
@@ -14,14 +14,13 @@ import ExtraFields from './ExtraFields';
 
 import NavBar from './NavBar';
 
-const padding = { margin: '0 2rem 0', padding: '1rem', border: '2px solid steelblue' };
 export default class App extends Component {
   render() {
     return (
       <BrowserRouter>
         <div>
           <Route path="*" component={NavBar} />
-          <div style={padding}>
+          <div>
             <Route path="/" exact component={Intro} />
             <Route path="/regular" exact component={RegularForm} />
             <Route path="/formatters" exact component={Formatters} />

--- a/packages/example/src/Formatters.js
+++ b/packages/example/src/Formatters.js
@@ -22,9 +22,7 @@ const stripNonNumeric = value => {
   return str;
 };
 
-const formatPhone = value => {
-  return new AsYouType('US').input(value);
-};
+const formatPhone = value => new AsYouType('US').input(value);
 
 const toUpperCase = value => value.toUpperCase();
 

--- a/packages/example/src/RegularForm.js
+++ b/packages/example/src/RegularForm.js
@@ -64,7 +64,7 @@ export default class RegularForm extends Component {
             </div>
 
             <div>
-              <Field type="checkbox" label="Checkbox field" name="checkboxaaa" value={true} />
+              <Field type="checkbox" label="Checkbox field" name="checkboxaaa" value />
             </div>
 
             <div>

--- a/packages/example/src/SliderForm.js
+++ b/packages/example/src/SliderForm.js
@@ -18,7 +18,7 @@ export default class SliderForm extends Component {
   render() {
     return (
       <div>
-        <Slider beforeSubmit={beforeSubmit} onSubmit={onSubmit} windowed slides={[]}>
+        <Slider beforeSubmit={beforeSubmit} onSubmit={onSubmit}>
           <Slide
             render={props => (
               <div>
@@ -44,11 +44,50 @@ export default class SliderForm extends Component {
               </div>
             )}
           />
-          <Slide>Slide One</Slide>
+          <Slide
+            render={props => (
+              <div>
+                <h2>Decision Tree</h2>
+                <p>
+                  Here are two radio buttons. If you choose the first one, you&apos;ll see the next
+                  slide and skip the one after that. If you choose the other one, you&apos;ll see
+                  the reverse.
+                </p>
+                <Radios
+                  validate={required}
+                  name="decisionTree"
+                  options={[
+                    { label: 'Next Slide', value: '0' },
+                    { label: 'The Other One', value: '1' },
+                  ]}
+                  value={props.getFormValues().decisionTree}
+                />
+              </div>
+            )}
+          />
+          <Slide shouldShowIf={values => values.decisionTree === '0'}>
+            <div>
+              <h2>You chose the first slide.</h2>
+              <p>(This is a static message, in case you&apos;re wondering).</p>
+            </div>
+          </Slide>
+          <Slide shouldShowIf={values => values.decisionTree === '1'}>
+            <div>
+              <h2>You skipped the last slide.</h2>
+              <p>(This is a static message, in case you&apos;re wondering).</p>
+            </div>
+          </Slide>
+          <Slide>
+            <h2>A static slide</h2>
+            <p>
+              This is a static slide. There is no need to set values in forms, so we don&apos;t need
+              to use a render prop.
+            </p>
+          </Slide>
           <Slide>
             <div>Testing, one, two, three.</div>
           </Slide>
-          <Slide render={props => <pre>{JSON.stringify(props, null, 2)}</pre>} />
+          <Slide render={props => <pre>{JSON.stringify(props.getFormValues(), null, 2)}</pre>} />
         </Slider>
       </div>
     );

--- a/packages/example/src/SliderForm.js
+++ b/packages/example/src/SliderForm.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-alert, react/prefer-stateless-function */
 import React, { Component } from 'react';
-import { Field, Radios, Submit } from '@flow-form/field';
+import { Field, Radios } from '@flow-form/field';
 import { Slide, Slider } from '@flow-form/slider';
 import '@flow-form/slider/dist/Slider.css';
 import '@flow-form/slider/dist/Slide.css';
@@ -45,6 +45,13 @@ export default class SliderForm extends Component {
             )}
           />
           <Slide
+            beforeExitToNext={({ getFormValues }) =>
+              new Promise(res => {
+                console.log('In beforeExitToNext hook');
+                alert(`You chose ${getFormValues().decisionTree}`);
+                res();
+              })
+            }
             render={props => (
               <div>
                 <h2>Decision Tree</h2>
@@ -84,10 +91,14 @@ export default class SliderForm extends Component {
               to use a render prop.
             </p>
           </Slide>
-          <Slide>
-            <div>Testing, one, two, three.</div>
-          </Slide>
-          <Slide render={props => <pre>{JSON.stringify(props.getFormValues(), null, 2)}</pre>} />
+          <Slide
+            render={props => (
+              <div>
+                <h2>These are all the values that were chosen</h2>
+                <pre>{JSON.stringify(props.getFormValues(), null, 2)}</pre>
+              </div>
+            )}
+          />
         </Slider>
       </div>
     );

--- a/packages/example/src/SliderForm.js
+++ b/packages/example/src/SliderForm.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-alert, react/prefer-stateless-function */
 import React, { Component } from 'react';
 import { Field, Radios, Submit } from '@flow-form/field';
-import { Slider } from '@flow-form/slider';
+import { Slide, Slider } from '@flow-form/slider';
 import '@flow-form/slider/dist/Slider.css';
 import '@flow-form/slider/dist/Slide.css';
 
@@ -18,91 +18,38 @@ export default class SliderForm extends Component {
   render() {
     return (
       <div>
-        <Slider
-          beforeSubmit={beforeSubmit}
-          onSubmit={onSubmit}
-          windowed
-          slides={[
-            {
-              key: 'first',
-              render: props => (
-                <div>
-                  <h1>A first question</h1>
-                  <Field
-                    type="text"
-                    name="first-question"
-                    validate={required}
-                    size={50}
-                    value={props.getFormValues()['first-question']}
-                    placeholder="This field is required"
-                  />
-                  <p>
-                    This slider has four slides. This one, two that we skip, and one with a submit
-                    button. After we <em>press</em> submit, we transform the value in the first to
-                    an uppercase string (<code>beforeSubmit</code>) that is passed to the actual
-                    submit (<code>onSubmit</code>) that is then logged to the console in the after
-                    submit method (<code>afterSubmit</code>).
-                  </p>
-                </div>
-              ),
-              onExit: values => {
-                console.log(values);
-              },
-            },
-            {
-              key: 'second',
-              render: props => (
-                <div>
-                  <h2>Decision Tree</h2>
-                  <p>
-                    Here are two radio buttons. If you choose the first one, you'll see the next
-                    slide and skip the one after that. If you choose the other one, you'll see the
-                    reverse.
-                  </p>
-                  <Radios
-                    validate={required}
-                    name="decisionTree"
-                    options={[
-                      { label: 'Next Slide', value: '0' },
-                      { label: 'The Other One', value: '1' },
-                    ]}
-                    value={props.getFormValues()['decisionTree']}
-                  />
-                </div>
-              ),
-            },
-            {
-              key: 'third-a',
-              render: (
-                <div>
-                  <h2>You chose the first slide.</h2>
-                  <p>(This is a static message, in case you&apos;re wondering).</p>
-                </div>
-              ),
-              shouldShowIf: values => values.decisionTree === '0',
-            },
-            {
-              key: 'third-b',
-              render: (
-                <div>
-                  <h2>You skipped the last slide.</h2>
-                  <p>(This is a static message, in case you&apos;re wondering).</p>
-                </div>
-              ),
-              shouldShowIf: values => values.decisionTree === '1',
-            },
-            {
-              key: 'fourth',
-              render: props => (
-                <div>
-                  <pre>{JSON.stringify(props.getFormValues(), null, 2)}</pre>
-                  <h2>I will show, and I&apos;m the last slide</h2>
-                  <Submit onSubmit={onSubmit} />
-                </div>
-              ),
-            },
-          ]}
-        />
+        <Slider beforeSubmit={beforeSubmit} onSubmit={onSubmit} windowed slides={[]}>
+          <Slide
+            render={props => (
+              <div>
+                <h1>A first question</h1>
+                <Field
+                  type="text"
+                  name="first-question"
+                  validate={required}
+                  size={50}
+                  value={props.getFormValues()['first-question']}
+                  placeholder="This field is required"
+                />
+                <p>
+                  This slider has four slides. This one, two that we skip, and one with a submit
+                  button. After we <em>press</em> submit, we transform the value in the first to an
+                  uppercase string (<code>beforeSubmit</code>) that is passed to the actual submit (<code
+                  >
+                    onSubmit
+                  </code>) that is then logged to the console in the after submit method (<code>
+                    afterSubmit
+                  </code>).
+                </p>
+              </div>
+            )}
+          />
+          <Slide>Slide One</Slide>
+          <Slide>
+            <div>Testing, one, two, three.</div>
+          </Slide>
+          <Slide render={props => <pre>{JSON.stringify(props, null, 2)}</pre>} />
+        </Slider>
       </div>
     );
   }

--- a/packages/form/src/Form.js
+++ b/packages/form/src/Form.js
@@ -48,7 +48,9 @@ export default class Form extends Component {
      * The form should have some fields
      */
     children: PropTypes.any.isRequired, // eslint-disable-line
-
+    /**
+     * Whether or not to keep the field values after the fields unmount
+     */
     keepUnmountedFieldValues: PropTypes.bool,
   };
 
@@ -56,11 +58,6 @@ export default class Form extends Component {
     autoComplete: 'on',
     noValidate: false,
     keepUnmountedFieldValues: false,
-  };
-
-  static contextTypes = {
-    registerForm: PropTypes.func,
-    unregisterForm: PropTypes.func,
   };
 
   static childContextTypes = {
@@ -115,19 +112,12 @@ export default class Form extends Component {
   }
 
   componentDidMount() {
-    if (this.context && isFunction(this.context.registerForm)) {
-      this.context.registerForm({
-        name: this.props.name,
-        getValues: this.getValues,
-        submit: this.handleOnSubmit,
-      });
-    }
+    this.setState({
+      isMounted: true,
+    });
   }
 
   componentWillUnmount() {
-    if (this.context && isFunction(this.context.unregisterForm)) {
-      this.context.unregisterForm(this.props.name);
-    }
     this.setState({
       isMounted: false,
     });
@@ -189,7 +179,7 @@ export default class Form extends Component {
 
       if (!isValid) {
         // Reject the promise and leave the function. We should handle this.
-        return rej({ error: 'Fields not valid.' });
+        return rej(new Error('Fields not valid.'));
       }
 
       // Grab all the field values

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@flow-form/form": "^0.0.1",
     "@flow-form/helpers": "^0.0.1",
+    "invariant": "^2.2.4",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/packages/slider/src/Slide.css
+++ b/packages/slider/src/Slide.css
@@ -1,22 +1,7 @@
 .ff--slide {
-  /*position: absolute;*/
-  /*will-change: transform;*/
-  /*transition: transform 0.6s ease-in-out, opacity 0.3s ease-in-out;*/
-  height: 100%;
-  width: 100%;
-  padding: 2rem;
+  padding: 2rem 4rem;
   z-index: 1;
   background-color: white;
-  /*transform: translateX(0);*/
   opacity: 1;
-}
-
-.ff--slide--prev {
-  /*transform: translateX(-100%);*/
-  opacity: 0;
-}
-
-.ff--slide--next {
-  /*transform: translateX(100%);*/
-  opacity: 0;
+  width: calc(100% - 8rem);
 }

--- a/packages/slider/src/Slide.js
+++ b/packages/slider/src/Slide.js
@@ -24,8 +24,6 @@ export default class Slide extends PureComponent {
   static childContextTypes = {
     registerField: PropTypes.func,
     unregisterField: PropTypes.func,
-    handleKey: PropTypes.func, // @TODO temp
-    handleTab: PropTypes.bool, // @TODO temp
   };
 
   constructor(props) {
@@ -91,23 +89,19 @@ export default class Slide extends PureComponent {
    *
    * @return {Boolean} [description]
    */
-  isValid = () => {
-    // Run through all the validations...
-    return (
-      Object.keys(this.fields)
-        .map(field => {
-          // Get the validity from the registered field
-          const fieldIsValid = this.fields[field].isValid();
-          if (!fieldIsValid) {
-            // Make the errors appear
-            this.fields[field].validate();
-          }
-          // Return the slide's validity to the slider
-          return fieldIsValid;
-        })
-        .filter(x => x === false).length === 0
-    );
-  };
+  isValid = () =>
+    Object.keys(this.fields)
+      .map(field => {
+        // Get the validity from the registered field
+        const fieldIsValid = this.fields[field].isValid();
+        if (!fieldIsValid) {
+          // Make the errors appear
+          this.fields[field].validate();
+        }
+        // Return the slide's validity to the slider
+        return fieldIsValid;
+      })
+      .filter(x => x === false).length === 0;
 
   render() {
     return (

--- a/packages/slider/src/Slide.js
+++ b/packages/slider/src/Slide.js
@@ -1,31 +1,22 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import isFunction from 'lodash/isFunction';
-import { autobind, classes, keyCodes } from '@flow-form/helpers';
+import { classes, moveCursor } from '@flow-form/helpers';
 
-const { ENTER, TAB } = keyCodes;
-
-const alwaysTrue = () => true;
-
-export default class Slide extends Component {
+export default class Slide extends PureComponent {
   static propTypes = {
-    shouldShowIf: PropTypes.func,
-    index: PropTypes.number.isRequired,
-    position: PropTypes.oneOf(['prev', 'current', 'next']).isRequired,
-    children: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.string]).isRequired,
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.string]),
     className: PropTypes.string,
-    getFormValues: PropTypes.func.isRequired,
-    afterSlide: PropTypes.func,
+    autoFocus: PropTypes.bool,
   };
 
   static defaultProps = {
-    shouldShowIf: alwaysTrue,
     className: '',
+    autoFocus: true,
+    children: null,
   };
 
   static contextTypes = {
-    registerSlide: PropTypes.func,
-    unregisterSlide: PropTypes.func,
     registerField: PropTypes.func,
     unregisterField: PropTypes.func,
   };
@@ -39,24 +30,7 @@ export default class Slide extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {
-      lastPosition: props.position,
-      hasShown: false,
-      willEnter: false,
-      willExit: false,
-    };
-    this.registerField = this.registerField.bind(this);
-    this.unregisterField = this.unregisterField.bind(this);
     this.fields = {};
-
-    autobind(this, [
-      'setRef',
-      'getRef',
-      'isValid',
-      'registerField',
-      'unregisterField',
-      'handleKey',
-    ]);
   }
 
   getChildContext() {
@@ -65,106 +39,12 @@ export default class Slide extends Component {
     return {
       registerField: this.registerField,
       unregisterField: this.unregisterField,
-      handleKey: this.handleKey, // @TODO temp
-      handleTab: true, // @TODO temp
     };
   }
 
   componentDidMount() {
-    if (isFunction(this.context.registerSlide)) {
-      const { index, beforeExit } = this.props;
-      this.context.registerSlide({
-        index,
-        beforeExit,
-        isValid: this.isValid,
-        getRef: this.getRef,
-      });
-    }
-    if (this.props.position === 'current' && this.fields[0]) {
-      const firstField = this.fields[0].getRef();
-      firstField.focus();
-    }
+    this.maybeAutoFocus();
   }
-
-  // @todo deprecate
-  componentWillReceiveProps(nextProps) {
-    const { position } = this.props;
-    const next = nextProps.position;
-    if (position !== next) {
-      this.setState({
-        willExit: position === 'current',
-        willExitPrev: position === 'current' && next === 'prev', // hitting the next button
-        willExitNext: position === 'current' && next === 'next', // hitting the prev button
-        willShow: next === 'current',
-        hasShown: !this.state.hasShown ? next === 'current' : true,
-        lastPosition: position,
-      });
-    }
-  }
-
-  // We don't want to rerender on state change
-  shouldComponentUpdate(nextProps) {
-    return this.props !== nextProps;
-  }
-
-  // @todo deprecate
-  componentWillUpdate(nextProps, nextState) {
-    if (nextState.willExitPrev) {
-      if (isFunction(this.props.afterSlide)) {
-        this.props.afterSlide({ values: this.props.getFormValues(), props: this.props.slideProps });
-      }
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.props.position === 'current' && this.fields[0]) {
-      const firstField = this.fields[0].getRef();
-      firstField.focus();
-    }
-  }
-
-  componentWillUnmount() {
-    if (isFunction(this.context.unregisterSlide)) {
-      this.context.unregisterSlide();
-    }
-  }
-
-  getRef = () => this.ref;
-
-  setRef = el => {
-    this.ref = el;
-  };
-
-  // this is a hack for tabs/enter @TODO temp
-  handleKey = (keyCode, modifiers, type, name, element) => {
-    const keys = Object.keys(this.fields);
-    let focusNext = false;
-    if (keyCode === ENTER || keyCode === TAB) {
-      if (modifiers.shiftKey) {
-        // Shift key means to go backwards
-        for (let i = keys.length - 1; i >= 0; i--) {
-          if (keys[i] === name) {
-            focusNext = true;
-          } else if (focusNext) {
-            const nextEl = this.fields[keys[i]].getRef();
-            nextEl.focus();
-            break;
-          }
-        }
-      } else {
-        // No shift key means to go forwards
-        for (let i = 0; i < keys.length; i++) {
-          if (keys[i] === name) {
-            focusNext = true;
-          } else if (focusNext) {
-            const nextEl = this.fields[keys[i]].getRef();
-            nextEl.focus();
-            break;
-          }
-        }
-      }
-    }
-  };
 
   registerField = ({ name, getRef, getValue, setValue, validate, reset, isValid }) => {
     if (isFunction(this.context.registerField)) {
@@ -188,6 +68,24 @@ export default class Slide extends Component {
     this.fields = remaining;
   };
 
+  maybeAutoFocus = () => {
+    if (this.props.autoFocus) {
+      const fieldNames = Object.keys(this.fields);
+      if (fieldNames.length > 0) {
+        // Get the element of the first field
+        const firstField = this.fields[fieldNames[0]].getRef();
+        // We need to push this top the next cycle in the event loop; otherwise we focus before
+        // it fully renders (which means, nothing actually happens).
+        setTimeout(() => {
+          // Call `focus` on the first field that we have
+          firstField.focus();
+          // Move the cursor to the end of the field
+          moveCursor(firstField);
+        }, 0);
+      }
+    }
+  };
+
   /**
    * Checks whether all registered fields on the slide are valid (they pass `validate` functions).
    *
@@ -195,31 +93,25 @@ export default class Slide extends Component {
    */
   isValid = () => {
     // Run through all the validations...
-    return Object.keys(this.fields).every(field => {
-      // Get the validity from the registered field
-      const fieldIsValid = this.fields[field].isValid();
-      if (!fieldIsValid) {
-        // Make the errors appear
-        this.fields[field].validate();
-      }
-      // Return the slide's validity to the slider
-      return fieldIsValid;
-    });
+    return (
+      Object.keys(this.fields)
+        .map(field => {
+          // Get the validity from the registered field
+          const fieldIsValid = this.fields[field].isValid();
+          if (!fieldIsValid) {
+            // Make the errors appear
+            this.fields[field].validate();
+          }
+          // Return the slide's validity to the slider
+          return fieldIsValid;
+        })
+        .filter(x => x === false).length === 0
+    );
   };
 
   render() {
-    const { className, position } = this.props;
-    const classNames = classes([
-      className,
-      'ff--slide',
-      position === 'prev' && 'ff--slide--prev',
-      position === 'current' && 'ff--slide--current',
-      position === 'next' && 'ff--slide--next',
-    ]);
     return (
-      <div className={classNames} ref={this.setRef}>
-        {this.props.children}
-      </div>
+      <div className={classes([this.props.className, 'ff--slide'])}>{this.props.children}</div>
     );
   }
 }

--- a/packages/slider/src/Slide.js
+++ b/packages/slider/src/Slide.js
@@ -3,17 +3,21 @@ import PropTypes from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import { classes, moveCursor } from '@flow-form/helpers';
 
+const alwaysTrue = () => true;
+
 export default class Slide extends PureComponent {
   static propTypes = {
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.string]),
     className: PropTypes.string,
     autoFocus: PropTypes.bool,
+    shouldShowIf: PropTypes.func,
   };
 
   static defaultProps = {
     className: '',
     autoFocus: true,
     children: null,
+    shouldShowIf: alwaysTrue,
   };
 
   static contextTypes = {

--- a/packages/slider/src/Slide.js
+++ b/packages/slider/src/Slide.js
@@ -7,10 +7,29 @@ const alwaysTrue = () => true;
 
 export default class Slide extends PureComponent {
   static propTypes = {
+    /**
+     * Regular react children.
+     * Note: do not use this with a `render` prop (as the children will be ignored)
+     */
     children: PropTypes.oneOfType([PropTypes.node, PropTypes.element, PropTypes.string]),
+    /**
+     * A className to put on the slide
+     */
     className: PropTypes.string,
+    /**
+     * If there is a <Field /> on the slide, then whether autoFocus the first one
+     */
     autoFocus: PropTypes.bool,
-    shouldShowIf: PropTypes.func,
+    /**
+     * Function that determines if the slide will show or be skipped; not used internally, but
+     * used by the Slider component
+     */
+    shouldShowIf: PropTypes.func, // eslint-disable-line
+    /**
+     * A render prop, which gets called by the <Slider /> component
+     * Note: do not use with children as the children will be ignored
+     */
+    render: PropTypes.func, // eslint-disable-line
   };
 
   static defaultProps = {
@@ -78,12 +97,14 @@ export default class Slide extends PureComponent {
         const firstField = this.fields[fieldNames[0]].getRef();
         // We need to push this top the next cycle in the event loop; otherwise we focus before
         // it fully renders (which means, nothing actually happens).
-        setTimeout(() => {
-          // Call `focus` on the first field that we have
-          firstField.focus();
-          // Move the cursor to the end of the field
-          moveCursor(firstField);
-        }, 0);
+        if (firstField) {
+          setTimeout(() => {
+            // Call `focus` on the first field that we have
+            firstField.focus();
+            // Move the cursor to the end of the field
+            moveCursor(firstField);
+          }, 0);
+        }
       }
     }
   };

--- a/packages/slider/src/Slider.css
+++ b/packages/slider/src/Slider.css
@@ -7,23 +7,42 @@
   width: 100%;
 }
 
-.ff--slider--control {
+.ff--slider form {
+  width: 100%;
+}
+
+.ff--slider-control {
   cursor: pointer;
   padding: 0.25rem;
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 0;
+  bottom: 0;
+  height: 100%;
   z-index: 999;
+  background-color: rgba(0, 0, 0, 0.25);
+  color: rgba(250, 250, 250, 0.95);
+  width: 2rem;
+  transition: background-color ease-in-out 0.2s;
+  font-size: 1.25rem;
 }
 
-.ff--slider--control--disabled {
+.ff--slider-control:hover {
+  background-color: rgba(0, 0, 0, 0.75);
+}
+
+.ff--slider-control:disabled {
   cursor: not-allowed;
 }
 
-.ff--slider--control--left {
+.ff--slider-control:active,
+.ff--slider-control:focus {
+  outline: none;
+}
+
+.ff--slider-control-left {
   left: 0;
 }
 
-.ff--slider--control--right {
+.ff--slider-control-right {
   right: 0;
 }

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -23,36 +23,36 @@ export default class Slider extends PureComponent {
      */
     current: PropTypes.number,
     /**
-     * The slide to start on
+     * Turn on/off autocomplete for the form
      */
     autoComplete: PropTypes.oneOf(['on', 'off']),
     /**
-     * The slide to start on
+     * A className or classNames to pass to the slider
      */
     className: PropTypes.string, // eslint-disable-line
     /**
-     * The slide to start on
+     * The slides. These should only be of type <Slide />
      */
     children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)])
       .isRequired,
     /**
-     * The slide to start on
+     * A button to use as a previous button
      */
     PrevButton: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     /**
-     * The slide to start on
+     * A button to use as a next button
      */
     NextButton: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
     /**
-     * The slide to start on
+     * The beforSubmit hook to pass to the form
      */
     beforeSubmit: PropTypes.func,
     /**
-     * The slide to start on
+     * The submit handler to pass to the form
      */
     onSubmit: PropTypes.func.isRequired,
     /**
-     * The slide to start on
+     * The afterSubmit hook to pass to the form
      */
     afterSubmit: PropTypes.func,
     /**

--- a/packages/slider/src/Slider.js
+++ b/packages/slider/src/Slider.js
@@ -191,6 +191,9 @@ export default class Slider extends PureComponent {
   };
 
   prev = () => {
+    // The logic of the slide beforeExit slide hooks is basically the same as for the `next` method
+    // that's just above. Refer to the inline comments above for a better explanation of what is
+    // happening here.
     const prevSlideIndex = this.findPrev();
     if (prevSlideIndex !== this.state.current) {
       const { beforeExit, beforeExitToPrev } = this.current.props;
@@ -220,12 +223,7 @@ export default class Slider extends PureComponent {
     const length = children.length; // eslint-disable-line
     for (let i = current + 1; i <= length - 1; i++) {
       const slide = children[i];
-      const { shouldShowIf } = slide.props;
-      if (isFunction(shouldShowIf)) {
-        if (shouldShowIf(formValues)) {
-          return i;
-        }
-      } else {
+      if (slide.props.shouldShowIf(formValues)) {
         return i;
       }
       // No valid candidate for next slide, so we test the next
@@ -250,12 +248,7 @@ export default class Slider extends PureComponent {
     const length = children.length; // eslint-disable-line
     for (let i = current - 1; i >= 0; i--) {
       const slide = children[i];
-      const { shouldShowIf } = slide.props;
-      if (isFunction(shouldShowIf)) {
-        if (shouldShowIf(formValues)) {
-          return i;
-        }
-      } else {
+      if (slide.props.shouldShowIf(formValues)) {
         return i;
       }
       // No valid candidate for next slide, so we test the next

--- a/yarn.lock
+++ b/yarn.lock
@@ -5780,7 +5780,7 @@ into-stream@^3.1.0:
     from2 "^2.1.1"
     p-is-promise "^1.1.0"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:


### PR DESCRIPTION
Slides are now written with JSX like they should be (this is a React library, after all).

Slides must be in a Slider component, and a Slider's children must be only slides.

All sliders are now windowed.

TODO: 

* need to add back in the slide hooks